### PR TITLE
Support build with IPv6 enabled only

### DIFF
--- a/src/drivers/driver_zephyr.c
+++ b/src/drivers/driver_zephyr.c
@@ -702,11 +702,13 @@ static int wpa_drv_zep_set_supp_port(void *priv,
 				     authorized,
 				     if_ctx->bssid);
 
+#ifdef CONFIG_NET_DHCPV4
 	if (authorized) {
 		net_dhcpv4_stop(iface);
 		k_msleep(500);
 		net_dhcpv4_start(iface);
     }
+#endif
 
 	return ret;
 }

--- a/src/l2_packet/l2_packet_zephyr.c
+++ b/src/l2_packet/l2_packet_zephyr.c
@@ -231,11 +231,15 @@ void l2_packet_deinit(struct l2_packet_data *l2)
 
 int l2_packet_get_ip_addr(struct l2_packet_data *l2, char *buf, size_t len)
 {
+#ifdef CONFIG_NET_IPV4
 	char addr_buf[NET_IPV4_ADDR_LEN];
 	os_strlcpy(buf, net_addr_ntop(AF_INET,
 				&l2->iface->config.ip.ipv4->unicast[0].address.in_addr.s_addr,
 				addr_buf, sizeof(addr_buf)), len);
 	return 0;
+#else
+	return -1;
+#endif
 }
 
 void l2_packet_notify_auth_start(struct l2_packet_data *l2)


### PR DESCRIPTION
Add proper pre-processor conditions to the code that uses
IPv4 API.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>